### PR TITLE
feat(playback) Converts controls to single play/pause button. Fixes #55

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,8 +8,8 @@ module.exports = function (grunt) {
     // bit of bullshit to ensure the build fails for missing files in the concat task
     // note this overrides normal logging! not cool.
     // These problems (failing on missing files) are expected to be resolved in grunt 0.5
-    grunt.log.oldWarn = grunt.log.warn;
-    grunt.log.warn = grunt.warn;
+    //grunt.log.oldWarn = grunt.log.warn;
+    //grunt.log.warn = grunt.warn;
 
     /**
      * Load required Grunt tasks. These are installed based on the versions listed

--- a/src/app/annotationViewer/_annotation_viewer.scss
+++ b/src/app/annotationViewer/_annotation_viewer.scss
@@ -115,6 +115,10 @@ baw-annotation-viewer {
       top:  0;
       left: 0;
       @include vendor-prefix(transform, translatex(0 px));
+
+      &.hidden {
+        display: none;
+      }
     }
   }
 

--- a/src/app/annotationViewer/annotationViewer.tpl.html
+++ b/src/app/annotationViewer/annotationViewer.tpl.html
@@ -18,7 +18,7 @@
             <img ng-src="{{model.media.spectrogram.url}}" src=""
                  ng-style="{width: model.converters.conversions.enforcedImageWidth, height: model.converters.conversions.enforcedImageHeight}">
             <div id="spectrogramAnnotations_{{id}}" ></div>
-            <div class="positionLine" baw-translate-x="positionLine()"></div>
+            <div class="positionLine" baw-translate-x="positionLine()" ng-class="{hidden: !model.audioElement.canPlay}" ></div>
         </div>
     </div>
 

--- a/src/app/listen/listen.js
+++ b/src/app/listen/listen.js
@@ -443,6 +443,15 @@ angular.module('bawApp.listen', ['decipher.tags', 'ui.bootstrap.typeahead'])
                     $scope.model.selectedAudioEvent = null;
                 };
 
+                $scope.togglePlayState = function togglePlay() {
+                    if ($scope.model.audioElement.isPlaying) {
+                        $scope.model.audioElement.pause();
+                    }
+                    else {
+                        $scope.model.audioElement.play();
+                    }
+                };
+
 
                 $scope.singleEditDisabled = function () {
                     return ($scope.model.selectedAudioEvent === null || $scope.model.selectedAudioEvent.id === undefined);

--- a/src/app/listen/listen.tpl.html
+++ b/src/app/listen/listen.tpl.html
@@ -47,12 +47,14 @@
                     <button class="btn btn-default" ng-click="model.audioElement.toStart()" title='Back to Start'>
                         <span class="glyphicon glyphicon-repeat"></span>
                     </button>
-                    <button class="btn btn-default" ng-click="model.audioElement.pause()" title='Pause'>
-                        <span class="glyphicon glyphicon-pause"></span>
+                    <button ng-disabled="!model.audioElement.canPlay"
+                            class="btn btn-default"
+                            ng-click="togglePlayState()"
+                            title="{{ model.audioElement.isPlaying && 'Pause' || 'Play' }}">
+                        <span ng-class="{'glyphicon-pause': model.audioElement.isPlaying}"
+                              class="glyphicon glyphicon-play"></span>
                     </button>
-                    <button class="btn btn-default" ng-click="model.audioElement.play()" title='Play'>
-                        <span class="glyphicon glyphicon-play"></span>
-                    </button>
+
 
                 </div>
                 <div class="btn-group">


### PR DESCRIPTION
Also, importantly, adds new states to the audioElement model like `canPlay` and `isPlaying`.
Also hides position/seek line and disables play/pause button when media cannot play.
