### PR TITLE
fix(annotations) isReference correctly triggers a save when it is modified

### DIFF
--- a/src/components/directives/bawAnnotationViewer.js
+++ b/src/components/directives/bawAnnotationViewer.js
@@ -409,6 +409,13 @@ bawds.directive('bawAnnotationViewer',
                     changedAnnotation.$intermediateEvent = null;
                     modelUpdatesServer(scope, changedAnnotation);
                 }
+
+                // reset $intermediateEvent - warning unknown effects. Modified so that single-edit changes will persist
+                if (changedAnnotation.$intermediateEvent) {
+                    changedAnnotation.$intermediateEvent = false;
+                }
+
+
             }
 
             function modelCollectionUpdated(newCollection, oldCollection, scope) {


### PR DESCRIPTION
Fixes #81 

The $intermediateEvent flag was never lowered meaning changes from the single edit view that did not trigger drawabox rendering never got saved.
The flag is reset on each modelUpdated function call now.
