### PR TITLE
fix(grid) Replaced element.innerText with element.textContent 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,6 @@
   "dependencies": {},
   "private": true,
   "resolutions": {
-    "angular": "1.3.1"
+    "angular": "1.3.2"
   }
 }

--- a/src/app/annotationViewer/gridLines/gridLines.js
+++ b/src/app/annotationViewer/gridLines/gridLines.js
@@ -103,7 +103,7 @@ bawGLs.directive('gridLines',
 
                     if (innerText) {
                         var label = formatter(steps[j].value, j, steps.min, steps.max);
-                        element.innerText = label;
+                        element.textContent = label;
                         biggest = label.length > biggest ? label.length : biggest;
                     }
 


### PR DESCRIPTION
So that it works in Firefox (`innerText` is not defined in Firefox).

Closes #140
