### PR TITLE
feat(visualise) Make tiles navigatible

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,8 @@
     "momentjs": "~2.8.x",
     "objectdiff": "https://github.com/NV/objectDiff.js.git",
     "round-date": "~1.0.1",
-    "sass-bootstrap": "3.0.2"
+    "sass-bootstrap": "3.0.2",
+    "angular-loading-bar": "~0.7.1"
   },
   "dependencies": {},
   "private": true,

--- a/buildConfig/build.config.js
+++ b/buildConfig/build.config.js
@@ -123,7 +123,9 @@ module.exports = {
             'vendor/angular-growl-v2/build/angular-growl.js',
             'vendor/angular-local-storage/dist/angular-local-storage.js',
             'vendor/humanize-duration/humanize-duration.js',
-            'vendor/round-date/roundDate.js'
+            'vendor/round-date/roundDate.js',
+
+            'vendor/angular-loading-bar/build/loading-bar.js'
         ],
         css: [
             // NOTE: bootstrap css imported in application.tpl.scss
@@ -135,7 +137,9 @@ module.exports = {
             //'vendor/select2/select2.css'
 
             'vendor/angular-tags/dist/angular-tags-0.3.1.css',
-            'vendor/angular-growl-v2/build/angular-growl.css'
+            'vendor/angular-growl-v2/build/angular-growl.css',
+
+            'vendor/angular-loading-bar/build/loading-bar.css'
         ],
         assets: [
             // jquery-ui is stoopid, special case

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -60,6 +60,7 @@ var app = angular.module('baw',
                              'decipher.tags',
                              'angular-growl',
                              'LocalStorageModule',
+                             'angular-loading-bar',
                              "bawApp.vendorServices", /* Loads all vendor libraries that are automatically wrapped in a module */
 
 
@@ -113,8 +114,8 @@ var app = angular.module('baw',
                              "bawApp.visualize"
                          ])
 
-    .config(['$routeProvider', '$locationProvider', '$httpProvider', 'conf.paths', 'conf.constants', '$sceDelegateProvider', 'growlProvider', 'localStorageServiceProvider', "$urlProvider", "casingTransformers",
-             function ($routeProvider, $locationProvider, $httpProvider, paths, constants, $sceDelegateProvider, growlProvider, localStorageServiceProvider, $urlProvider, casingTransformers) {
+    .config(["$provide", '$routeProvider', '$locationProvider', '$httpProvider', 'conf.paths', 'conf.constants', '$sceDelegateProvider', 'growlProvider', 'localStorageServiceProvider', "cfpLoadingBarProvider", "$urlProvider", "casingTransformers",
+             function ($provide, $routeProvider, $locationProvider, $httpProvider, paths, constants, $sceDelegateProvider, growlProvider, localStorageServiceProvider, cfpLoadingBarProvider, $urlProvider, casingTransformers) {
                  // adjust security whitelist for resource urls
                  var currentWhitelist = $sceDelegateProvider.resourceUrlWhitelist();
                  currentWhitelist.push(paths.api.root+'/**');
@@ -207,8 +208,20 @@ var app = angular.module('baw',
                  // configure local storage provider with our own namepspace
                  localStorageServiceProvider.setPrefix(constants.namespace);
 
+                 // for compatibility with rails api
                  $urlProvider.renamer(function(key) {
                      return casingTransformers.underscore(key);
+                 });
+
+                 // configure the loader bar
+                 // only show bar after waiting for 200ms
+                 cfpLoadingBarProvider.latencyThreshold = 200;
+                 // add a standard way to add ignores to http objects
+                 $provide.decorator('cfpLoadingBar', function ($delegate) {
+                     $delegate.ignore = function ($httpConfig) {
+                         return $httpConfig && ($httpConfig.ignoreLoadingBar = true, $httpConfig) || $httpConfig;
+                     };
+                     return $delegate;
                  });
              }])
 

--- a/src/app/d3Bindings/eventDistribution/_eventDistribution.scss
+++ b/src/app/d3Bindings/eventDistribution/_eventDistribution.scss
@@ -1,4 +1,44 @@
-$mini-backgrounds: darksalmon darkolivegreen slategray #8f7f6f #7a6f8f #8f6f8f;
+//http://paletton.com/#uid=72S0B0kmqrpsOf3p4mljsvMfRHr
+$color-primary-0: #32A746;	/* Main Primary color */
+$color-primary-1: #095C18;
+$color-primary-2: #1D8830;
+$color-primary-3: #4CC261;
+$color-primary-4: #6EDA81;
+
+$color-secondary-1-0: #2F6A8B;	/* Main Secondary color (1) */
+$color-secondary-1-1: #0B354C;
+$color-secondary-1-2: #1D5471;
+$color-secondary-1-3: #4480A1;
+$color-secondary-1-4: #69A6C6;
+
+$color-secondary-2-0: #DA9541;	/* Main Secondary color (2) */
+$color-secondary-2-1: #78470C;
+$color-secondary-2-2: #B27227;
+$color-secondary-2-3: #FDB763;
+$color-secondary-2-4: #FFC581;
+
+$color-complement-0: #DA4D41;	/* Main Complement color */
+$color-complement-1: #78140C;
+$color-complement-2: #B23127;
+$color-complement-3: #FD6F63;
+$color-complement-4: #FF8A81;
+
+$mini-backgrounds: (
+    $color-primary-0 $color-secondary-1-0  $color-secondary-2-0 $color-complement-0
+    $color-primary-1 $color-secondary-1-1  $color-secondary-2-1 $color-complement-1
+    $color-primary-2 $color-secondary-1-2  $color-secondary-2-2 $color-complement-2
+    $color-primary-3 $color-secondary-1-3  $color-secondary-2-3 $color-complement-3
+    $color-primary-4 $color-secondary-1-4  $color-secondary-2-4 $color-complement-4
+);
+
+//$mini-backgrounds: darksalmon darkolivegreen slategray #8f7f6f #7a6f8f #8f6f8f;
+
+$visualize-no-data-color: #DDD;
+$tile-border-color: #777;
+$tile-background-color: #e5ffd8;
+$generating-tile-color:  $text-color;
+$legend-size: 2em;
+
 
 event-distribution-overview, event-distribution-detail {
 
@@ -75,30 +115,33 @@ event-distribution-visualisation {
     .imageTrack {
 
       .tiles {
-        background-color: paleturquoise;
+        background-color: $visualize-no-data-color;
         position: relative;
         height: 256px;
 
         .tile {
           width: 60px;
-          border: grey solid 1px;
-          border-left: deeppink solid 1px;
-          border-right: blue solid 1px;
-          background-color: rgba(255, 0, 0, 0.2);
+          border: $tile-border-color solid 1px;
+          //border-left: deeppink solid 1px;
+          //border-right: blue solid 1px;
+          background-color: $tile-background-color;
           height: 256px;
-          display: inline-block;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+
           position: absolute;
+          text-align: center;
+
+          cursor: pointer;
 
           & div {
             font-size: 8pt;
-            color: white;
-            height: 60px;
-            width: 256px;
-            @include vendor-prefix(transform, rotate(-90deg));
-            @include vendor-prefix(transform-origin, right center 0);
-            top: -31px;
-            right: 30px;
-            position: absolute;
+            color: $generating-tile-color;
+            font-weight: bold;
+            padding: 0 1px;
+            width: 100%;
+            flex: none;
           }
         }
       }
@@ -111,5 +154,32 @@ event-distribution-visualisation {
 
       }
     }
+
+  dl {
+
+    dt {
+      width: $legend-size;
+      height: $legend-size;
+      display: inline-block;
+      vertical-align: middle;
+
+      border: $tile-border-color solid 1px;
+    }
+
+    dd {
+      display: inline;
+      margin-right: 1em;
+      vertical-align: middle;
+
+    }
+
+    .missing {
+      background-color: $visualize-no-data-color;
+    }
+
+    .generating {
+      background-color: $tile-background-color;
+    }
+  }
 
 }

--- a/src/app/d3Bindings/eventDistribution/distributionDetail.js
+++ b/src/app/d3Bindings/eventDistribution/distributionDetail.js
@@ -178,7 +178,7 @@ angular
                         .clipPath("url(#" + clipId + ")")
                         .classed("mainItemsGroup", true);
 
-                    xAxis = new TimeAxis(main, xScale, {position: [0, mainHeight]});
+                    xAxis = new TimeAxis(main, xScale, {position: [0, mainHeight], isVisible: false});
                 }
 
                 function updateDataVariables(data) {

--- a/src/app/d3Bindings/eventDistribution/distributionOverview.js
+++ b/src/app/d3Bindings/eventDistribution/distributionOverview.js
@@ -62,7 +62,7 @@ angular
                     updateDimensions();
 
                     mini = createMini(chart);
-                    xAxis = new TimeAxis(mini, xScale, {position: [0, miniHeight]});
+                    xAxis = new TimeAxis(mini, xScale, {position: [0, miniHeight], isVisible: false});
                 }
 
                 function updateData(data) {
@@ -77,7 +77,7 @@ angular
                     if (data && data.items.length > 0) {
                         display();
 
-                        xAxis.update(xScale, [0, miniHeight]);
+                        xAxis.update(xScale, [0, miniHeight], true);
                     }
                 }
 

--- a/src/app/d3Bindings/eventDistribution/distributionVisualisation.tpl.html
+++ b/src/app/d3Bindings/eventDistribution/distributionVisualisation.tpl.html
@@ -12,7 +12,12 @@
         <!--<img ng-src="assets/temp/eabad986-56d9-47b5-bec6-47458ffd3eae_101023-0000.ACI-ENT-EVN-trimmed-PLACEHOLDER.png"-->
              <!--src=""/>-->
     <!--</div>-->
-
+    <dl>
+        <dt class="missing">&nbsp;</dt>
+        <dd>= no audio data</dd>
+        <dt class="generating">&nbsp;</dt>
+        <dd>= visualisation generating</dd>
+    </dl>
     <p>&nbsp;</p>
     <p>&nbsp;</p>
     <p>&nbsp;</p>

--- a/src/app/d3Bindings/eventDistribution/eventDistributionController.js
+++ b/src/app/d3Bindings/eventDistribution/eventDistributionController.js
@@ -26,6 +26,10 @@ angular
                     },
                     getText: function (d) {
                         return d.text;
+                    },
+                    getTileUrl: function(date, category, tileSizeSeconds, tileSizePixels, datum, index) {
+                        var hourOfDay = date.getHours();
+                        return "/tile_" + hourOfDay + ".png"
                     }
                 };
 

--- a/src/app/d3Bindings/eventDistribution/eventDistributionController.js
+++ b/src/app/d3Bindings/eventDistribution/eventDistributionController.js
@@ -29,7 +29,7 @@ angular
                     },
                     getTileUrl: function(date, category, tileSizeSeconds, tileSizePixels, datum, index) {
                         var hourOfDay = date.getHours();
-                        return "/tile_" + hourOfDay + ".png"
+                        return "/tile_" + hourOfDay + ".png";
                     }
                 };
 

--- a/src/app/d3Bindings/widgets/timeAxis.js
+++ b/src/app/d3Bindings/widgets/timeAxis.js
@@ -14,7 +14,7 @@ angular
                         position: [0, 0],
                         isVisible: true
                     },
-                    options = angular.extend(defaultOptions, options),
+                    options = angular.extend(defaultOptions, _options),
                     scale = _scale || d3.time.scale(),
                     axisG;
 

--- a/src/app/visualize/_visualize.scss
+++ b/src/app/visualize/_visualize.scss
@@ -18,6 +18,15 @@
       }
     }
   }
+
+  .loadingImage {
+    $loadGifPath:  image-url('load.gif');
+    background: $loadGifPath center center no-repeat;
+    width: 100%;
+    height: 60px;
+
+
+  }
 }
 
 

--- a/src/app/visualize/visualize.js
+++ b/src/app/visualize/visualize.js
@@ -46,14 +46,6 @@ angular
                 );
             }
 
-            /*
-             $http.get("assets/temp/dummyData.json").then(function (response) {
-             $scope.recordingData = response.data;
-             }, function () {
-             console.error("loading dummy data failed", arguments);
-             });
-             */
-
             // options that bind the generic event distribution
             // controls to our particular data structures
             $scope.distributionOptions = {
@@ -87,6 +79,12 @@ angular
                     },
                     getText: function (d) {
                         return d.id;
+                    },
+                    getTileUrl: function(date, category, tileSizeSeconds, tileSizePixels, datum, index) {
+                        //var hourOfDay = date.getHours();
+
+                        // do not attempt to load dll's for demo
+                        return;
                     }
                 }
             };

--- a/src/app/visualize/visualize.js
+++ b/src/app/visualize/visualize.js
@@ -21,6 +21,7 @@ angular
             $scope.filterType = null;
             $scope.sites = [];
             $scope.projects = [];
+            $scope.isLoading = true;
 
 
             var parameters = validateParameters();
@@ -38,6 +39,8 @@ angular
                 chain.then(sitesRetrieved)
                     .then(getOtherData)
                     .then(processOtherData, function error() {
+                        $scope.isLoading = false;
+
                         if (!$scope.errorState) {
                             $scope.errorState = "an unknown error occurred";
                         }
@@ -81,10 +84,15 @@ angular
                         return d.id;
                     },
                     getTileUrl: function(date, category, tileSizeSeconds, tileSizePixels, datum, index) {
-                        //var hourOfDay = date.getHours();
+                        var hourOfDay = date.getHours();
+
+                        if (datum.source.id !== 188238) {
+                            return;
+                        }
 
                         // do not attempt to load dll's for demo
-                        return;
+                        var url = "/assets/temp/demo/188238_" + hourOfDay + ".png";
+                        return url;
                     }
                 }
             };
@@ -232,6 +240,8 @@ angular
 
             function processOtherData(results) {
                 console.debug("Visualise data promise chain success", arguments);
+
+                $scope.isLoading = false;
 
                 var projects = results[1].data.data;
                 $scope.projects = projects;

--- a/src/app/visualize/visualize.tpl.html
+++ b/src/app/visualize/visualize.tpl.html
@@ -32,12 +32,13 @@
 
         <section class="row">
             <event-distribution-overview></event-distribution-overview>
-            <!--{{distributionOptions.overviewExtent}}-->
+            <div ng-if="isLoading" class="loadingImage"></div>
         </section>
 
         <section class="row">
             <h3>Detailed view for {{distributionOptions.detailDuration}}</h3>
             <event-distribution-detail></event-distribution-detail>
+            <div ng-if="isLoading" class="loadingImage"></div>
         </section>
 
         <section class="row">

--- a/src/components/services/audioRecording.js
+++ b/src/components/services/audioRecording.js
@@ -23,9 +23,15 @@ angular
 
             resource.getRecordingsForVisulisation = function (siteIds) {
                 var query = QueryBuilder.create(function (q) {
+
+                    // HACK: ask for a ridiculous amount of items since
+                    // paging cap automatically is enabled at 500 items.
+                    // TODO: add an option to disable paging
+                    // track issue here: https://github.com/QutBioacoustics/baw-server/issues/160
                     return q
                         .in("siteId", siteIds)
-                        .project({include: ["id", "siteId", "durationSeconds", "recordedDate"]});
+                        .project({include: ["id", "siteId", "durationSeconds", "recordedDate"]})
+                        .page({items: 100000, page: 1});
                 });
 
                 return $http.post(filterUrl, query.toJSON());

--- a/src/components/services/predictiveCache.js
+++ b/src/components/services/predictiveCache.js
@@ -1,5 +1,5 @@
 angular
-    .module("bawApp.services.predictiveCache", [])
+    .module("bawApp.services.predictiveCache", ["angular-loading-bar"])
     .factory(
     "predictiveCacheInterceptor",
     [
@@ -34,7 +34,8 @@ angular
         "$http",
         "predictiveCacheInterceptor",
         "$q",
-        function ($http, predictiveCacheInterceptor, $q) {
+        "cfpLoadingBar",
+        function ($http, predictiveCacheInterceptor, $q, cfpLoadingBar) {
 
             var defaults = {
                 name: null,
@@ -169,10 +170,15 @@ angular
 
                 function invokeHttp(url) {
                     console.debug("predictiveCache:promiseResolution enqueued " + url);
-                    return $http({
+                    var config = {
                         url: url,
                         method: profile.method
-                    }).then(function (value) {
+                    };
+                    //HACK: this is nasty... only done so unit tests pass
+                    if (cfpLoadingBar.ignore) {
+                        config = cfpLoadingBar.ignore(config);
+                    }
+                    return $http(config).then(function (value) {
                         console.debug("predictiveCache:promiseResolution completed " + url);
                         return value;
                     });

--- a/src/components/services/predictiveCache.spec.js
+++ b/src/components/services/predictiveCache.spec.js
@@ -6,7 +6,18 @@ describe("The predictiveCache service", function () {
         $httpProvider = _$httpProvider_;
     }));
 
+    //beforeEach(module("baw"));
+
     beforeEach(function () {
+        //
+        //$provide.decorator('cfpLoadingBar', function ($delegate) {
+        //    $delegate.ignore = function ($httpConfig) {
+        //        return $httpConfig && ($httpConfig.ignoreLoadingBar = true) || $httpConfig;
+        //    };
+        //
+        //    return $delegate;
+        //});
+
         testProfile = {
             name: "Media cache ahead",
             match: /google\.com\?page=(.*)&size=(.*)/,


### PR DESCRIPTION
The tiles will now redirect a user to the audio to play when clicked.

Other changes made:
- Lane colors changed for overview and detail controls
- legend added below visualise control
- Fixed the paging bug - default page size is hacked to `100,000` items
- Site wide AJAX loading bars added to improve feel (especially for long loading time scenarios)
- Loading bars package actually saved to bower.json
- Annoying TimeAxis labels are no longer visible while the page is loading
- TimeAxis now actually merges is provided options, rather than just ignoring them!
- Loading spinner gifs added in place of overview and detail controls while data is loading
 