### PR TITLE
fix(visualize) Visualize smart click

### DIFF
--- a/src/app/d3Bindings/eventDistribution/distributionVisualisation.js
+++ b/src/app/d3Bindings/eventDistribution/distributionVisualisation.js
@@ -71,7 +71,8 @@ angular
                 // init
                 create();
 
-                // functions
+                /* exported functions */
+
                 function updateData(data) {
                     updateDataVariables(data);
 
@@ -101,6 +102,8 @@ angular
 
                     updateElements();
                 }
+
+                /* internal functions*/
 
                 function create() {
                     updateDataVariables(data);
@@ -257,20 +260,7 @@ angular
                         .attr(gAttrs)
                         .translate(tileGTranslation)
                         .classed("tile", true)
-                        .on("click", function (datum) {
-                                // HACK: temporary behaviour for demo
-                                // construct url
-                                var ar = datum.source,
-                                    id = ar.id,
-                                    startOffset = (datum.offset - ar.recordedDate) / 1000,
-                                    endOffset = startOffset + 30.0;
-
-                                var url = "/listen/" + id + "?start=" + startOffset + "&end=" + endOffset;
-
-                                console.warn("navigating to ", url);
-
-                                window.location = url;
-                            });
+                        .on("click", navigateToAudio);
                     newTileElements.append("rect")
                         .attr(imageAttrs);
 
@@ -305,6 +295,8 @@ angular
 
                     xAxis.update(xScale, [0, tilesHeight], showAxis);
                 }
+
+                /* helper functions */
 
                 function updateResolution() {
                     resolution = tileSizeSeconds / tileSizePixels;
@@ -393,6 +385,21 @@ angular
                     }
 
                     return "";
+                }
+
+                function navigateToAudio(datum) {
+                    // HACK: temporary behaviour for demo
+                    // construct url
+                    var ar = datum.source,
+                        id = ar.id,
+                        startOffset = (datum.offset - ar.recordedDate) / 1000,
+                        endOffset = startOffset + 30.0;
+
+                    var url = "/listen/" + id + "?start=" + startOffset + "&end=" + endOffset;
+
+                    console.warn("navigating to ", url);
+
+                    //window.location = url;
                 }
 
             }

--- a/src/app/listen/listen.js
+++ b/src/app/listen/listen.js
@@ -70,7 +70,7 @@ angular.module('bawApp.listen', ['decipher.tags', 'ui.bootstrap.typeahead'])
                 // parse the start and end offsets
                 $routeParams.start = parseFloat($routeParams.start) || 0.0;
                 // warn: this converts 0 to chunk duration
-                $routeParams.end = parseFloat($routeParams.end) || CHUNK_DURATION_SECONDS;
+                $routeParams.end = parseFloat($routeParams.end) || ($routeParams.start + CHUNK_DURATION_SECONDS);
                 var chunkDuration = ($routeParams.end - $routeParams.start);
                 if (chunkDuration < 0) {
 

--- a/src/components/services/audioRecording.js
+++ b/src/components/services/audioRecording.js
@@ -28,7 +28,8 @@ angular
                     return q
                         .in("siteId", siteIds)
                         .project({include: ["id", "siteId", "durationSeconds", "recordedDate"]})
-                        .page.disable();
+                        .page.disable()
+                        .sort({orderBy: "id"});
                 });
 
                 return $http.post(filterUrl, query.toJSON());


### PR DESCRIPTION
fix(visualize) Navigating on tile click now works better

Fixes #186 and #189
  - Audio recordings are now returned from the API in a consistent order (#189)
  - Tile navigation on `click` event changed to SVG `a` elements
    - better usability (accessibility, middle clicking, control clicking, right-clicking)
	- hover over to see link 
	- pre computed links slightly faster
  - fixed a bug with tile generation behaviour (extra tiles are no longer generated)
  - tiles are also sorted when filtered (no z-indexing in svg, insertion order important)
  - also fixed bug where tiles would be prematurely cut from screen if the duration of the source audio was too short
  - Also fixes #193