### PR TITLE
feat(visualize) Allow on zoom/pan padding off edge of dataset

### DIFF
--- a/src/app/d3Bindings/eventDistribution/_eventDistribution.scss
+++ b/src/app/d3Bindings/eventDistribution/_eventDistribution.scss
@@ -34,24 +34,24 @@ $color-complement-3: #FF7368;
 $color-complement-4: #FF938A;
 
 $mini-backgrounds: (
-    $color-primary-0 $color-secondary-1-0  $color-secondary-2-0 $color-complement-0
-    $color-primary-1 $color-secondary-1-1  $color-secondary-2-1 $color-complement-1
-    $color-primary-2 $color-secondary-1-2  $color-secondary-2-2 $color-complement-2
-    $color-primary-3 $color-secondary-1-3  $color-secondary-2-3 $color-complement-3
-    $color-primary-4 $color-secondary-1-4  $color-secondary-2-4 $color-complement-4
+        $color-primary-0 $color-secondary-1-0 $color-secondary-2-0 $color-complement-0 $color-primary-1 $color-secondary-1-1 $color-secondary-2-1 $color-complement-1 $color-primary-2 $color-secondary-1-2 $color-secondary-2-2 $color-complement-2 $color-primary-3 $color-secondary-1-3 $color-secondary-2-3 $color-complement-3 $color-primary-4 $color-secondary-1-4 $color-secondary-2-4 $color-complement-4
 );
 
 //$mini-backgrounds: darksalmon darkolivegreen slategray #8f7f6f #7a6f8f #8f6f8f;
 
-$visualize-no-data-color: #DDD;
+$out-of-bounds-color: #DDD;
+$dataset-in-bounds-bg-color: #ffffff;
+
 $tile-border-color: #777;
+
 $tile-background-color: #e5ffd8;
 $generating-tile-color: $text-color;
 $legend-size: 2em;
 
-$standard-brush-fill: rgba(30, 144, 255, 0.32);
+$standard-brush-fill: rgba(30, 144, 255, 0.2);
 $visualization-brush-fill: rgba(mix($standard-brush-fill, white), 1.0);
 $visualization-brush-lane-overlay-fill: $standard-brush-fill;
+$visualization-brush-stroke: $gray-light;
 
 event-distribution-overview, event-distribution-detail {
 
@@ -116,12 +116,20 @@ event-distribution-detail {
     font: 13px sans-serif;
   }
 
+  .outOfBounds {
+    fill: $out-of-bounds-color;
+  }
+
+  .datasetBounds {
+    fill: $dataset-in-bounds-bg-color;
+  }
+
   .visualizationBrushArea {
     fill: $visualization-brush-fill;
   }
 
   .visualizationBrushLaneOverlay {
-    stroke: $tile-border-color;
+    stroke: $visualization-brush-stroke;
     fill: $visualization-brush-lane-overlay-fill;
   }
 }
@@ -142,7 +150,11 @@ event-distribution-visualisation {
     }
 
     .tilesBackground {
-      fill: $visualize-no-data-color;
+      fill: $out-of-bounds-color;
+    }
+
+    .datasetBounds {
+      fill: $dataset-in-bounds-bg-color;
     }
 
     .tiles {
@@ -186,8 +198,12 @@ event-distribution-visualisation {
 
     }
 
-    .missing {
-      background-color: $visualize-no-data-color;
+    .outOfBounds {
+      background-color: $out-of-bounds-color;
+    }
+
+    .noAudioInDataset {
+      background-color: $dataset-in-bounds-bg-color;
     }
 
     .generating {

--- a/src/app/d3Bindings/eventDistribution/distributionVisualisation.js
+++ b/src/app/d3Bindings/eventDistribution/distributionVisualisation.js
@@ -25,6 +25,7 @@ angular
                 //metaTrack = container.select(".metaTrack"),
                     main = container.select(".imageTrack .main"),
                     tilesBackground = main.select(".tilesBackground"),
+                    datasetBoundsRect = main.select(".datasetBounds"),
                     tilesGroup = main.select(".tiles"),
                     tilesClipRect,
 
@@ -53,7 +54,7 @@ angular
                     margin = {
                         top: 13,
                         right: 0,
-                        left: 0 + yAxisWidth,
+                        left: 120 /* yAxisWidth*/,
                         bottom: 0 + xAxisHeight
                     },
 
@@ -122,7 +123,8 @@ angular
                 function updateDataVariables(data) {
                     // data should be an array of items with extents
                     self.items = data.items;
-
+                    self.maximum = data.maximum;
+                    self.minimum = data.minimum;
                     self.nyquistFrequency = data.nyquistFrequency;
                     self.spectrogramWindowSize = data.spectrogramWindowSize;
                     self.middle = null;
@@ -147,6 +149,7 @@ angular
                     };
                     tilesGroup.attr(attrs);
                     tilesBackground.attr(attrs);
+                    datasetBoundsRect.attr("height", tilesHeight);
                     if (tilesClipRect) {
                         tilesClipRect.attr(attrs);
                     }
@@ -293,6 +296,17 @@ angular
 
                     // remove old tiles
                     tileElements.exit().remove();
+
+                    // update datasetBounds
+                    // effect a manual clip on the range
+                    var dbMinimum = Math.max(visibleExtent[0], self.minimum);
+                    var dbMaximum = Math.min(visibleExtent[1], self.maximum);
+                    xScale.clamp(true);
+                    datasetBoundsRect.attr({
+                        x: xScale(dbMinimum) || 0.0,
+                        width: Math.max(0, xScale(dbMaximum) - xScale(dbMinimum)) || 0.0
+                    });
+                    xScale.clamp(false);
 
                     var domain = xScale.domain(),
                     // intentionally falsey

--- a/src/app/d3Bindings/eventDistribution/distributionVisualisation.tpl.html
+++ b/src/app/d3Bindings/eventDistribution/distributionVisualisation.tpl.html
@@ -5,6 +5,7 @@
     <svg >
         <g class="main">
             <rect class="tilesBackground"></rect>
+            <rect class="datasetBounds"></rect>
             <!-- there should usually be at most 25 tiles -->
             <g class="tiles">
 
@@ -12,6 +13,8 @@
         </g>
     </svg>
     <dl>
+        <dt class="outOfBounds">&nbsp;</dt>
+        <dd>= outside of dataset</dd>
         <dt class="missing">&nbsp;</dt>
         <dd>= no audio data</dd>
         <dt class="generating">&nbsp;</dt>


### PR DESCRIPTION
Fixes #184 

Also added style consistency between visualization and detail controls and updated legend
  (out of bounds is consistently gray, no audio data is white)

Also padded out left margin on visualization control so that the middle of all controls is aligned

Both the visualization and detail views now have two rects that paint out of bounds and missing data.

Distribution overview updated so that will clip the brush (because it is now possible to move the brush up to halfway out of bounds).

The detail view now allows panning/zooming up to half of the visible extent off either edge.
The amount available to pan by (in terms of time) changes at each zoom level but is actually always a constant width (half the screen of data)