### PR TITLE
Post messages to workbench-client

### DIFF
--- a/buildConfig/environmentSettings.json
+++ b/buildConfig/environmentSettings.json
@@ -4,6 +4,8 @@
       "apiRoot": "https://staging.ecosounds.org",
       "siteRoot": "http://development.ecosounds.org:4200",
       "siteDir": "/assets/old-client/",
+      "parentRoot": "http://localhost:4200",
+      "parentDir": "/",
       "ga": {
         "trackingId": ""
       }

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -126,6 +126,35 @@ angular.module("baw",
     .config(
         ["$provide", "$routeProvider", "$locationProvider", "$httpProvider", "conf.paths", "conf.constants", "$sceDelegateProvider", "growlProvider", "localStorageServiceProvider", "cfpLoadingBarProvider", "$urlProvider", "casingTransformers",
             function ($provide, $routeProvider, $locationProvider, $httpProvider, paths, constants, $sceDelegateProvider, growlProvider, localStorageServiceProvider, cfpLoadingBarProvider, $urlProvider, casingTransformers) {
+                /**
+                 * Browsers calculate heights of document differently. Take the
+                 * largest measurement to combat this
+                 * https://stackoverflow.com/questions/1145850/how-to-get-height-of-entire-document-with-javascript
+                 * @returns Height
+                 */
+                function getHeight() {
+                    const body = document.body;
+                    const html = document.documentElement;
+                    return Math.max(
+                        body.scrollHeight,
+                        body.offsetHeight,
+                        html.offsetHeight
+                        // These values cause weird behavior
+                        // html.clientHeight,
+                        // html.scrollHeight,
+                    );
+                }
+
+                /*
+                 * Detect change in height of browser, and post message to
+                 * parent page (workbench-client) with the new value
+                 */
+                const resizeObserver = new ResizeObserver(() => { // jshint ignore:line
+                    window.parent.postMessage(JSON.stringify({height: getHeight()}), constants.parentRoot);
+                });
+                resizeObserver.observe(document.documentElement);
+                resizeObserver.observe(document.body);
+                
                 // adjust security whitelist for resource urls
                 var currentWhitelist = $sceDelegateProvider.resourceUrlWhitelist();
                 currentWhitelist.push(paths.api.root + "/**");


### PR DESCRIPTION
This is a sister change to https://github.com/QutEcoacoustics/workbench-client/pull/1587 and just determines the height of the current page, monitors for any changes, and posts the message to the parent container. The changes to the config have already been enabled in the following commit on baw private: https://github.com/QutEcoacoustics/baw-private/commit/c8021b3b324733ad67c1a2d95b0abd2076490f11